### PR TITLE
Fixes breaking podspec

### DIFF
--- a/ios/RNImageStore.podspec
+++ b/ios/RNImageStore.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNImageStore
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/tradle/react-native-image-store"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Was seeing this error once I migrated the lib to CocoaPods

```ruby
[!] The `RNImageStore` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
```

On a side note, there were two additional warnings, which I did not address

```ruby
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```